### PR TITLE
move AMDGPU_TARGETS before include Dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ option(BUILD_CLIENTS_BENCHMARKS "Build benchmarks (requires boost)" OFF)
 option(BUILD_CLIENTS_SAMPLES "Build examples" ON)
 option(BUILD_VERBOSE "Output additional build information" OFF)
 
+# AMD targets
+set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
+
 # Dependencies
 include(cmake/Dependencies.cmake)
 
@@ -89,9 +92,6 @@ include(cmake/Dependencies.cmake)
 set(VERSION_STRING "1.18.2")
 rocm_setup_version(VERSION ${VERSION_STRING})
 set(rocsparse_SOVERSION 0.1)
-
-# AMD targets
-set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
 
 # rocSPARSE library
 add_subdirectory(library)


### PR DESCRIPTION
AMDGPU_TARGETS marked as cache string.
When after include Dependencies.cmake, AMDGPU_TARGETS always get cached variable gfx900;gfx906;gfx908, Its means never used AMDGPU_TARGETS.
This caused ROCm3.9 crashed on gfx803. https://github.com/RadeonOpenCompute/ROCm/issues/1269

resolves #___

Summary of proposed changes:
-
-
-
